### PR TITLE
Add .js extension to package.json main key

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
             "url": "https://github.com/ProperJS/KonamiCode/blob/master/LICENSE"
         }
     ],
-    "main": "KonamiCode",
+    "main": "KonamiCode.js",
     "keywords": [
         "properjs",
         "konami code",


### PR DESCRIPTION
Tiny nit but this causes resolution errors in modern bundlers as the new ESM syntax doesn't support implicit extensions for resolution.

Thus, all extensions must now be specified for e.g. Rollup and the like to property detect and resolve them.